### PR TITLE
Update vc-storage to latest and removed customDocumentLoader

### DIFF
--- a/app/utils/credential.ts
+++ b/app/utils/credential.ts
@@ -12,7 +12,6 @@ import { Ed25519Signature2020 } from '@digitalcredentials/ed25519-signature-2020
 // @ts-ignore
 import { customDocumentLoader } from '@cooperation/vc-storage/dist/utils/digitalbazaar.js'
 import { v4 as uuidv4 } from 'uuid'
-import * as hrContextObj from 'hr-context'
 
 function getCredentialEngine(accessToken: string): CredentialEngine {
   if (!accessToken) {
@@ -99,24 +98,7 @@ const signCred = async (
         unsignedCredential.evidence = evidenceItems
       }
 
-      const wrappedDocumentLoader = async (url: string) => {
-        if (url === 'https://w3id.org/hr/v1' || url === 'https://w3id.org/hr/v1/') {
-          return {
-            contextUrl: null,
-            documentUrl: url,
-            document: (hrContextObj as any).CONTEXT_V1 || (hrContextObj as any).contexts?.get(url)
-          }
-        }
-        if (url === 'https://www.w3.org/ns/credentials/v2' || url === 'https://www.w3.org/ns/credentials/v2/') {
-          const v1Doc = await customDocumentLoader('https://www.w3.org/2018/credentials/v1')
-          return {
-            contextUrl: null,
-            documentUrl: url,
-            document: v1Doc.document
-          }
-        }
-        return customDocumentLoader(url)
-      }
+      const wrappedDocumentLoader = customDocumentLoader
 
       const suite = new Ed25519Signature2020({ key: keyPair, verificationMethod: keyPair.id })
       signedVC = await dbVc.issue({ credential: unsignedCredential, suite, documentLoader: wrappedDocumentLoader })

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
-    "@cooperation/vc-storage": "^1.0.42",
+    "@cooperation/vc-storage": "^1.0.44",
     "@digitalbazaar/ed25519-signature-2020": "^5.4.0",
     "@digitalcredentials/ed25519-signature-2020": "^7.0.0",
     "@digitalcredentials/ed25519-verification-key-2020": "^5.0.0-beta.1",


### PR DESCRIPTION
In this PR
Fixed VC signing by removing LinkedCreds-Author’s custom JSON-LD loader override and delegating to @cooperation/vc-storage’s customDocumentLoader, which already provides the corrected HR context handling.
This resolves the jsonld.SyntaxError (@context @type must be an absolute IRI) seen in signCred during SkillClaim credential issuance.